### PR TITLE
ADD: pd.read_csv 할 때 dict to str 되는 문제 해결

### DIFF
--- a/load_data.py
+++ b/load_data.py
@@ -1,6 +1,7 @@
 import pickle as pickle
 import os
 import pandas as pd
+from ast import literal_eval
 import torch
 from sklearn.model_selection import StratifiedShuffleSplit
 
@@ -20,20 +21,18 @@ class RE_Dataset(torch.utils.data.Dataset):
 
 def preprocessing_dataset(dataset):
     """ 처음 불러온 csv 파일을 원하는 형태의 DataFrame으로 변경 시켜줍니다."""
-    subject_entity = []
-    object_entity = []
-    for i,j in zip(dataset['subject_entity'], dataset['object_entity']):
-        i = i[1:-1].split(',')[0].split(':')[1]
-        j = j[1:-1].split(',')[0].split(':')[1]
+    sub_df = dataset['subject_entity'].apply(pd.Series).add_prefix('sub_')
+    obj_df = dataset['object_entity'].apply(pd.Series).add_prefix('obj_')
+    dataset = pd.concat([dataset, sub_df], axis=1)
+    dataset = pd.concat([dataset, obj_df], axis=1)
+    #dataset = dataset.drop(['subject_entity', 'object_entity'], axis=1)
 
-        subject_entity.append(i)
-        object_entity.append(j)
-    out_dataset = pd.DataFrame({'id':dataset['id'], 'sentence':dataset['sentence'],'subject_entity':subject_entity,'object_entity':object_entity,'label':dataset['label'],})
-    return out_dataset
+    return dataset
 
 def load_data(dataset_dir):
     """ csv 파일을 경로에 맡게 불러 옵니다. """
-    pd_dataset = pd.read_csv(dataset_dir)
+    pd_dataset = pd.read_csv(dataset_dir, 
+                converters={'subject_entity':literal_eval, 'object_entity':literal_eval})
     dataset = preprocessing_dataset(pd_dataset)
     
     return dataset
@@ -46,9 +45,6 @@ def split_data(dataset):
     
     return train_dataset,dev_dataset
 
-
-
-
 def tokenized_dataset(dataset, tokenizer):
     """ tokenizer에 따라 sentence를 tokenizing 합니다."""
     concat_entity = []
@@ -56,6 +52,7 @@ def tokenized_dataset(dataset, tokenizer):
         temp = ''
         temp = e01 + '[SEP]' + e02
         concat_entity.append(temp)
+        
     tokenized_sentences = tokenizer(
         concat_entity,
         list(dataset['sentence']),


### PR DESCRIPTION
## 제목
pd.read_csv() 수행 시 기존 dict로 저장된 파일이 str로 read되는 문제 해결

## 작업 내용
* ast.iteral_eval를 사용해서 dict 형식으로 불러오도록 했습니다.
* 불러온 dict 파일을 column으로 분해했습니다. -> sub_word, sub_start_idx, sub_end_idx, sub_type,,, also obj
* dataset(pd.DataFrame)에서 column 정보로 접근이 가능해졌습니다.

## 주의 사항

## 리뷰어에게 전하는 말
